### PR TITLE
Adding support for struct fields from env variables

### DIFF
--- a/gonfig.go
+++ b/gonfig.go
@@ -191,7 +191,7 @@ func setJSONStringToArray(f reflect.Value, value string) {
 	for i, v := range jsonArr {
 		jsonItemVal, err := json.Marshal(v)
 		if err != nil {
-			fmt.Errorf("Cannot marshall array itemelement")
+			fmt.Errorf("Cannot marshall array item element")
 			return
 		}
 		setValue(f.Index(i), string(jsonItemVal[:]))

--- a/gonfig.go
+++ b/gonfig.go
@@ -4,6 +4,7 @@
 package gonfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -82,39 +83,45 @@ func getFromEnvVariables(configuration interface{}) {
 			if s.Kind() == reflect.Struct {
 				// exported field
 				f := s.FieldByName(p.Name)
-				if f.IsValid() && f.CanSet() {
-					// A Value can be changed only if it is
-					// addressable and was not obtained by
-					// the use of unexported struct fields.
-
-					// change value
-					kind := f.Kind()
-					if kind == reflect.Int || kind == reflect.Int64 {
-						setStringToInt(f, value, 64)
-					} else if kind == reflect.Int32 {
-						setStringToInt(f, value, 32)
-					} else if kind == reflect.Int16 {
-						setStringToInt(f, value, 16)
-					} else if kind == reflect.Uint || kind == reflect.Uint64 {
-						setStringToUInt(f, value, 64)
-					} else if kind == reflect.Uint32 {
-						setStringToUInt(f, value, 32)
-					} else if kind == reflect.Uint16 {
-						setStringToUInt(f, value, 16)
-					} else if kind == reflect.Bool {
-						setStringToBool(f, value)
-					} else if kind == reflect.Float64 {
-						setStringToFloat(f, value, 64)
-					} else if kind == reflect.Float32 {
-						setStringToFloat(f, value, 32)
-					} else if kind == reflect.String {
-						f.SetString(value)
-					}
-
-				}
+				setValue(f, value)
 			}
 		}
 	}
+}
+
+func setValue(f reflect.Value, value string) {
+	// change value
+	kind := f.Kind()
+
+	if f.IsValid() && f.CanSet() {
+		// A Value can be changed only if it is
+		// addressable and was not obtained by
+		// the use of unexported struct fields.
+		if kind == reflect.Int || kind == reflect.Int64 {
+			setStringToInt(f, value, 64)
+		} else if kind == reflect.Int32 {
+			setStringToInt(f, value, 32)
+		} else if kind == reflect.Int16 {
+			setStringToInt(f, value, 16)
+		} else if kind == reflect.Uint || kind == reflect.Uint64 {
+			setStringToUInt(f, value, 64)
+		} else if kind == reflect.Uint32 {
+			setStringToUInt(f, value, 32)
+		} else if kind == reflect.Uint16 {
+			setStringToUInt(f, value, 16)
+		} else if kind == reflect.Bool {
+			setStringToBool(f, value)
+		} else if kind == reflect.Float64 {
+			setStringToFloat(f, value, 64)
+		} else if kind == reflect.Float32 {
+			setStringToFloat(f, value, 32)
+		} else if kind == reflect.String {
+			f.SetString(value)
+		} else if kind == reflect.Struct {
+			setJSONStringToStruct(f, value)
+		}
+	}
+
 }
 
 func setStringToInt(f reflect.Value, value string, bitSize int) {
@@ -152,5 +159,19 @@ func setStringToFloat(f reflect.Value, value string, bitSize int) {
 		if !f.OverflowFloat(convertedValue) {
 			f.SetFloat(convertedValue)
 		}
+	}
+}
+
+func setJSONStringToStruct(f reflect.Value, value string) {
+
+	jsonMap := make(map[string]interface{})
+	err := json.Unmarshal([]byte(value), &jsonMap)
+	if err != nil {
+		fmt.Errorf("Cannot decode string into map")
+	}
+
+	for k, v := range jsonMap {
+		subField := f.Addr().Elem().FieldByName(k)
+		setValue(subField, fmt.Sprintf("%v", v))
 	}
 }

--- a/gonfig.go
+++ b/gonfig.go
@@ -178,9 +178,7 @@ func setJSONStringToStruct(f reflect.Value, value string) {
 }
 
 func setJSONStringToArray(f reflect.Value, value string) {
-
 	var jsonArr []interface{}
-
 	err := json.Unmarshal([]byte(value), &jsonArr)
 	if err != nil {
 		fmt.Errorf("Cannot decode string into array")

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -234,18 +234,18 @@ func Test_getFromCustomEnvVariables_should_find_and_parse_string(t *testing.T) {
 
 func Test_getFromCustomEnvVariables_should_find_and_parse_object(t *testing.T) {
 	type SubConf struct {
-		Id     string
+		ID     string
 		Number int
 	}
 	type Conf struct {
 		Subconf SubConf `env:"SUB_CONF_ID"`
 	}
-	os.Setenv("SUB_CONF_ID", "{\"Id\":\"abc\", \"Number\": 123}")
+	os.Setenv("SUB_CONF_ID", "{\"ID\":\"abc\", \"Number\": 123}")
 	conf := Conf{}
 	getFromEnvVariables(&conf)
 
-	if conf.Subconf.Id != "abc" {
-		t.Errorf("Id should be abc %s", conf.Subconf.Id)
+	if conf.Subconf.ID != "abc" {
+		t.Errorf("ID should be abc %s", conf.Subconf.ID)
 	}
 	if conf.Subconf.Number != 123 {
 		t.Errorf("Number should be 123 %d", conf.Subconf.Number)

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -231,3 +231,23 @@ func Test_getFromCustomEnvVariables_should_find_and_parse_string(t *testing.T) {
 		t.Error("Id should be abc", conf.Id)
 	}
 }
+
+func Test_getFromCustomEnvVariables_should_find_and_parse_object(t *testing.T) {
+	type SubConf struct {
+		Id     string
+		Number int
+	}
+	type Conf struct {
+		Subconf SubConf `env:"SUB_CONF_ID"`
+	}
+	os.Setenv("SUB_CONF_ID", "{\"Id\":\"abc\", \"Number\": 123}")
+	conf := Conf{}
+	getFromEnvVariables(&conf)
+
+	if conf.Subconf.Id != "abc" {
+		t.Errorf("Id should be abc %s", conf.Subconf.Id)
+	}
+	if conf.Subconf.Number != 123 {
+		t.Errorf("Number should be 123 %d", conf.Subconf.Number)
+	}
+}

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -251,3 +251,57 @@ func Test_getFromCustomEnvVariables_should_find_and_parse_object(t *testing.T) {
 		t.Errorf("Number should be 123 %d", conf.Subconf.Number)
 	}
 }
+
+func Test_getFromCustomEnvVariables_should_find_and_parse_JSONObjectArray(t *testing.T) {
+	type SubConf struct {
+		ID     string
+		Number int
+	}
+	type Conf struct {
+		Subconfs []SubConf `env:"SUB_CONFS"`
+	}
+	os.Setenv("SUB_CONFS", "[{\"ID\":\"abc\", \"Number\": 123},{\"ID\":\"def\", \"Number\": 456}]")
+	conf := Conf{}
+	getFromEnvVariables(&conf)
+
+	if len(conf.Subconfs) != 2 {
+		t.Errorf("Conf should have 2 Subconfs items %d", len(conf.Subconfs))
+	}
+
+	if conf.Subconfs[0].ID != "abc" {
+		t.Errorf("ID should be abc %s", conf.Subconfs[0].ID)
+	}
+	if conf.Subconfs[0].Number != 123 {
+		t.Errorf("Number should be 123 %d", conf.Subconfs[0].Number)
+	}
+	if conf.Subconfs[1].ID != "def" {
+		t.Errorf("ID should be def %s", conf.Subconfs[1].ID)
+	}
+	if conf.Subconfs[1].Number != 456 {
+		t.Errorf("Number should be 456 %d", conf.Subconfs[1].Number)
+	}
+}
+
+func Test_getFromCustomEnvVariables_should_find_and_parse_JSONArray(t *testing.T) {
+
+	type Conf struct {
+		Values []int `env:"SUB_VALUES"`
+	}
+	os.Setenv("SUB_VALUES", "[1,2,3]")
+	conf := Conf{}
+	getFromEnvVariables(&conf)
+
+	if len(conf.Values) != 3 {
+		t.Errorf("Conf should have 3 items %d", len(conf.Values))
+	}
+	if conf.Values[0] != 1 {
+		t.Errorf("Values[0] should be 1 %d", conf.Values[0])
+	}
+	if conf.Values[1] != 2 {
+		t.Errorf("Values[1] should be 2 %d", conf.Values[1])
+	}
+	if conf.Values[2] != 3 {
+		t.Errorf("Values[2] should be 3 %d", conf.Values[2])
+	}
+
+}

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -238,9 +238,9 @@ func Test_getFromCustomEnvVariables_should_find_and_parse_object(t *testing.T) {
 		Number int
 	}
 	type Conf struct {
-		Subconf SubConf `env:"SUB_CONF_ID"`
+		Subconf SubConf `env:"SUB_CONF"`
 	}
-	os.Setenv("SUB_CONF_ID", "{\"ID\":\"abc\", \"Number\": 123}")
+	os.Setenv("SUB_CONF", "{\"ID\":\"abc\", \"Number\": 123}")
 	conf := Conf{}
 	getFromEnvVariables(&conf)
 


### PR DESCRIPTION
Hi all!
As the title says, the idea behind this change is to support JSON string object's from environment variables. 
I've extracted the "switch" block to a new func named **setValue** in order to be called both from the existing func getFromEnvVariables and the new func **setJSONStringToStruct**.
The purpose of this new func is to Unmarshall the JSON string into a map, and iterate it calling the **setValue** func.