### PR TITLE
Added support for prefixed environment variables

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Go
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.17'
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gonfig
+# gonfig [![Go](https://github.com/g41797/gonfig/actions/workflows/go.yml/badge.svg)](https://github.com/g41797/gonfig/actions/workflows/go.yml)
 
 Fork of github.com/tkanos/gonfig - added "using prefixes for environment variables name"
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ $ docker run [...] -e Connection_String="..." [...]
 To make this simple for developers we can use gonfig to easily fill in our struct.
 
 ```bash
-$ go get github.com/tkanos/gonfig
+$ go get github.com/g41797/gonfig
 ```
 
 ```golang
-import "github.com/tkanos/gonfig"
+import "github.com/g41797/gonfig"
 
 configuration := Configuration{}
 err := gonfig.GetConf("pathtomyjonfile.json", &configuration)
@@ -73,11 +73,11 @@ type Configuration struct {
 
 ### using prefixes for environment variables name
 
-If 
-- an env attribute was not defined
-- environment variable with required name does not exist
- 
-gonfig looking for **prefixed** name. This name created from the name of the configuration file.
+If an env attribute was not defined , gonfig 
+- looking for **prefixed** name
+- if this name does not exist - tries to get using former name.
+
+Prefixed name created from the name of the configuration file.
 
 For example for file *example*.json:
 ```json
@@ -89,6 +89,8 @@ For example for file *example*.json:
 prefix will be **EXAMPLE_** and names of environment variables:
 - EXAMPLE_Port
 - EXAMPLE_Connection_String
+
+This feature allows to place the same variables used in different configuration files to environment.
 
 ## When should gonfig be used?
 
@@ -102,9 +104,9 @@ gonfig makes it easier to combine JSON and environment variables into one struct
 
 ## Sample
 
-You can find a sample of the use of Gonfig project [HERE](https://github.com/Tkanos/gonfig-sample)
+You can find a sample of the use of Gonfig project [HERE](https://github.com/tkanos/gonfig-sample)
 
 
 # Links
 - [Best practices of configuration file](https://medium.com/@tkanos/best-practices-for-configuration-file-in-your-code-2d6add3f4b86#.dze386j1t)
-- [Sample](https://github.com/Tkanos/gonfig-sample)
+- [Sample](https://github.com/g41797/gonfig-sample)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gonfig
 
-gonfig is a lightweight Golang package for intergrating both JSON configs and enviornment variables into one config object.
+gonfig is a lightweight Golang package for intergrating both JSON configs and environment variables into one config object.
 
 ## Usage
 
@@ -21,7 +21,7 @@ Then fill in our JSON file:
 }
 ```
 
-We do not define `Connection_String` in the JSON as we would prefer to define that through an enviornment variable.
+We do not define `Connection_String` in the JSON as we would prefer to define that through an environment variable.
 
 [Best practices of configuration file](https://medium.com/@tkanos/best-practices-for-configuration-file-in-your-code-2d6add3f4b86#.dze386j1t)
 
@@ -69,15 +69,34 @@ type Configuration struct {
 }
 ```
 
+### using prefixes for environment variables name
+
+If 
+- an env attribute was not defined
+- environment variable with required name does not exist
+ 
+gonfig looking for **prefixed** name. This name created from the name of the configuration file.
+
+For example for file *example*.json:
+```json
+{
+	"Port": 8080,
+    "Connection_String": "connection_string"
+}
+```
+prefix will be **EXAMPLE_** and names of environment variables:
+- EXAMPLE_Port
+- EXAMPLE_Connection_String
+
 ## When should gonfig be used?
 
-If you have a limited number of enviornment configuration variables, it's probably better to set the struct values yourself.
+If you have a limited number of environment configuration variables, it's probably better to set the struct values yourself.
 
 ```golang
 configuration.Connection_String = os.Getenv("Connection_String")
 ```
 
-gonfig makes it easier to combine JSON and enviornment variables into one struct automatically.
+gonfig makes it easier to combine JSON and environment variables into one struct automatically.
 
 ## Sample
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # gonfig
 
-gonfig is a lightweight Golang package for intergrating both JSON configs and environment variables into one config object.
+Fork of github.com/tkanos/gonfig - added "using prefixes for environment variables name"
+
+gonfig is a lightweight Golang package for integrating both JSON configs and environment variables into one config object.
 
 ## Usage
 

--- a/_config/example.json
+++ b/_config/example.json
@@ -1,0 +1,4 @@
+{
+	"Port": 8080,
+    "Connection_String": "connection_string"
+}

--- a/_config/example.json
+++ b/_config/example.json
@@ -1,4 +1,4 @@
 {
-	"Port": 8080,
+    "Port": 8080,
     "Connection_String": "connection_string"
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,91 @@
+package gonfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	gonfig "github.com/tkanos/gonfig"
+)
+
+type configuration struct {
+	Port              int
+	Connection_String string
+}
+
+//
+// because mixed testing environment, these test should be activated manually
+//
+
+func Test_unmarshalFromJSONFile_ToStruct(t *testing.T) {
+	expected := defaults()
+	actual := configuration{}
+	fPath := "./_config/example.json"
+	err := gonfig.GetConf(fPath, &actual)
+	compare(t, err, actual, expected)
+}
+
+func Test_unmarshalFromJSONFile_AndEnv_ToStruct(t *testing.T) {
+	expected := defaults()
+	expected.Port = 8443
+
+	os.Setenv("Port", strconv.Itoa((expected.Port)))
+
+	actual := configuration{}
+	fPath := "./_config/example.json"
+	err := gonfig.GetConf(fPath, &actual)
+	compare(t, err, actual, expected)
+}
+
+// ------------------------------------------------------------------------------------------
+// -- Manually run test under vscode:
+// go test -run ^Test_unmarshalFromJSONFile_AndPrefixedEnv_ToStruct$ github.com/tkanos/gonfig
+// ------------------------------------------------------------------------------------------
+func Test_unmarshalFromJSONFile_AndPrefixedEnv_ToStruct(t *testing.T) {
+	expected := defaults()
+	expected.Port = 8443
+	fPath := "./_config/example.json"
+
+	os.Setenv(envPrefix(fPath)+"Port", strconv.Itoa((expected.Port)))
+
+	actual := configuration{}
+	err := gonfig.GetConf(fPath, &actual)
+	compare(t, err, actual, expected)
+}
+
+func defaults() configuration {
+	return configuration{Port: 8080, Connection_String: "connection_string"}
+}
+
+func compare(t *testing.T, getErr error, actual configuration, expected configuration) {
+	if getErr != nil {
+		t.Errorf("unmarshal error %v", getErr)
+	}
+
+	if actual.Connection_String != expected.Connection_String {
+		t.Errorf("Expected %s Actual %s", expected.Connection_String, actual.Connection_String)
+	}
+
+	if actual.Port != expected.Port {
+		t.Errorf("Expected %d Actual %d", expected.Port, actual.Port)
+	}
+}
+
+func envPrefix(fPath string) string {
+	prefix := strings.ToUpper(baseFileName(fPath)) + "_"
+	return prefix
+}
+
+func baseFileName(fPath string) string {
+	if len(fPath) == 0 {
+		return ""
+	}
+
+	file := filepath.Base(fPath)
+	ext := filepath.Ext(file)
+	name := strings.TrimSuffix(file, ext)
+
+	return name
+}

--- a/config_test.go
+++ b/config_test.go
@@ -41,13 +41,14 @@ func Test_unmarshalFromJSONFile_AndEnv_ToStruct(t *testing.T) {
 
 // ------------------------------------------------------------------------------------------
 // -- Manually run test under vscode:
-// go test -run ^Test_unmarshalFromJSONFile_AndPrefixedEnv_ToStruct$ github.com/tkanos/gonfig
+// go test -run ^Test_unmarshalFromJSONFile_AndPrefixedEnv_ToStruct$ github.com/g41797/gonfig
 // ------------------------------------------------------------------------------------------
 func Test_unmarshalFromJSONFile_AndPrefixedEnv_ToStruct(t *testing.T) {
 	expected := defaults()
 	expected.Port = 8443
 	fPath := "./_config/example.json"
 
+	os.Setenv("Port", "8080")
 	os.Setenv(envPrefix(fPath)+"Port", strconv.Itoa((expected.Port)))
 
 	actual := configuration{}

--- a/config_test.go
+++ b/config_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	gonfig "github.com/tkanos/gonfig"
+	gonfig "github.com/g41797/gonfig"
 )
 
 type configuration struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tkanos/gonfig
+module github.com/g41797/gonfig
 
 go 1.17
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/tkanos/gonfig
+
+go 1.17
+
+require github.com/ghodss/yaml v1.0.0
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/gonfig_test.go
+++ b/gonfig_test.go
@@ -2,7 +2,6 @@ package gonfig
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -22,7 +21,7 @@ func Test_GetFromYAML_Filename_Empty_Should_Not_Panic(t *testing.T) {
 
 func tmpFileWithContent(content string, t *testing.T) string {
 
-	file, err := ioutil.TempFile("", "gonfig_test_data_")
+	file, err := os.CreateTemp("", "gonfig_test_data_")
 	if err != nil {
 		t.Error("Error creating file with test data", err)
 	}


### PR DESCRIPTION
We tried to use [viper](https://github.com/spf13/viper).
But it does not support our flow.

Our process has number of components.
Component has own json configuration file.
Part of parameters may be overridden via environment variables.
We need convenient way to save "the same" environment variables for different components.
We cannot use environment attributes in struct, because the same code may be run as component with different name.

Added feature was described in [readme](https://github.com/g41797/gonfig#using-prefixes-for-environment-variables-name)

Additional changes
- adding working in mod environment
- separated test for added functionality


